### PR TITLE
refactor/style(pmd): remove enforcement for control statement braces in single-line statements

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -9,5 +9,7 @@
         frc5183/librobot ruleset.
     </description>
 
-    <rule ref="rulesets/java/quickstart.xml"/>
+    <rule ref="rulesets/java/quickstart.xml">
+        <exclude name="ControlStatementBraces"/>
+    </rule>
 </ruleset>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated ruleset configuration to exclude the `ControlStatementBraces` rule, allowing more flexibility in control statement formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->