### PR TITLE
ci/refactor(build/test): change build java job to test java

### DIFF
--- a/.github/workflows/grade-publish.yml
+++ b/.github/workflows/grade-publish.yml
@@ -13,7 +13,7 @@ on:
             - published
 
 jobs:
-    build:
+    publish:
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -1,4 +1,4 @@
-name: Build Java
+name: Test Java
 
 on:
     push:
@@ -14,7 +14,7 @@ on:
     pull_request:
 
 jobs:
-    build-java:
+    test-java:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -29,5 +29,5 @@ jobs:
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v3
 
-            - name: Build
-              run: ./gradlew build --scan
+            - name: Test
+              run: ./gradlew test


### PR DESCRIPTION
since testing will build anyway, and we don't upload any artifacts from the build

also changes the "build" step in publish to "publish" because it was bothering me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for publishing Gradle packages.
	- Added a testing workflow for Java applications.

- **Updates**
	- Renamed job from `build` to `publish` for the Gradle publish workflow.
	- Updated permissions to allow writing to packages.
	- Changed the workflow purpose from building to testing for Java applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->